### PR TITLE
Rotate Perlin to reduce visible grid alignment

### DIFF
--- a/Assets/TerrainGenerator/Code/Generator/Noise/NoiseProvider.cs
+++ b/Assets/TerrainGenerator/Code/Generator/Noise/NoiseProvider.cs
@@ -20,7 +20,21 @@ namespace TerrainGenerator
 
         public float GetValue(float x, float z)
         {
-            return (float)(PerlinNoiseGenerator.GetValue(x, 0, z) / height) + damper;
+            (float xr, float yr, float zr) = rotateXZBeforeY(x, 0, z);
+            return (float)(PerlinNoiseGenerator.GetValue(xr, yr, zr) / height) + damper;
+        }
+
+        // Old Perlin noise can be visibly grid-aligned. Simplex-type noise is usually better about that.
+        // However, in the absence of Simplex, 3D Perlin can be rotated to hide the grid in X/Z planes.
+        private (float xr, float yr, float zr) rotateXZBeforeY(float x, float y, float z)
+        {
+            float xz = x + z;
+            float yy = y * 0.577350269189626f;
+            float s2 = xz * -0.211324865405187f + yy;
+            float xr = x + s2;
+            float zr = z + s2;
+            float yr = xz * -0.577350269189626f + yy;
+            return (xr, yr, zr);
         }
 
     }

--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Should work out of the box but no promises.
 [Video demo here](https://youtu.be/55BXqpLDkn4)
 
 Fork me, patch me, make me better!
+
+
+Changelog
+---
+
+* Add 3D rotation transform to reduce visible grid alignment in perlin noise. (Feb 21, 2020)


### PR DESCRIPTION
Raw Perlin noise can appear grid aligned. But you can improve variety of directions that mountains can be oriented along, if you re-orient the input coordinates. Both screenshots were taken with the noise frequency artificially doubled, and player Y position locked at 384.

Before:
![image](https://user-images.githubusercontent.com/8829856/75084752-4bded380-54f0-11ea-9929-d697b6f2b4c6.png)

After:
![image](https://user-images.githubusercontent.com/8829856/75084754-500af100-54f0-11ea-84e9-f1544c07d652.png)